### PR TITLE
Make test less confusing

### DIFF
--- a/tests/testCoadd.py
+++ b/tests/testCoadd.py
@@ -93,11 +93,10 @@ class CoaddTestCase(unittest.TestCase):
         np.random.seed(0)
 
         coadd = None
-        wcs = None
         for imInd in range(numImages):
             maskedImage = afwTestUtils.makeGaussianNoiseMaskedImage(
                 dimensions=imShape, sigma=imSigma, variance=imVariance)
-            exposure = afwImage.ExposureF(maskedImage, wcs)
+            exposure = afwImage.ExposureF(maskedImage)
 
             if not coadd:
                 coadd = coaddChiSq.Coadd(
@@ -149,10 +148,9 @@ class CoaddTestCase(unittest.TestCase):
         np.random.seed(0)
 
         coadd = None
-        wcs = None
         maskedImage = afwTestUtils.makeGaussianNoiseMaskedImage(
             dimensions=imShape, sigma=imSigma, variance=imVariance)
-        inExp = afwImage.ExposureF(maskedImage, wcs)
+        inExp = afwImage.ExposureF(maskedImage)
 
         coadd = coaddChiSq.Coadd(
             bbox=inExp.getBBox(),


### PR DESCRIPTION
The test was creating an exposure using ExposureF(maskedImage, wcs)
with wcs = None. This works, but is confusing; better to omit
the wcs argument.
